### PR TITLE
fix: Headers parsing fix

### DIFF
--- a/docusaurus-utils/scrapper/markdown-convertor.mjs
+++ b/docusaurus-utils/scrapper/markdown-convertor.mjs
@@ -14,7 +14,7 @@ function enhanceMarkdownWithBulletPointsCorrected(input) {
       inFrontMatter = !inFrontMatter
       if (!inFrontMatter && contributorsLines.length) {
         // We're exiting frontmatter; time to add contributors
-        extractedFields.push(`contributors:\n${contributorsLines.join('\n')}`)
+        extractedFields.push(`contributors\n${contributorsLines.join('\n')}`)
         contributorsLines = [] // Reset for safety
       }
       return line // Keep the frontmatter delimiters
@@ -24,14 +24,11 @@ function enhanceMarkdownWithBulletPointsCorrected(input) {
       if (line.startsWith('contributors:')) {
         inContributors = true // Entering contributors section
       } else if (inContributors) {
-        if (line.startsWith('  -')) {
-          console.log(line)
+        if (line.trim().startsWith('-')) {
           contributorsLines.push(line.trim()) // Add contributors line
         } else {
           // Exiting contributors section
           inContributors = false
-          extractedFields.push(`contributors:\n${contributorsLines.join('\n')}`)
-          contributorsLines = [] // Reset
         }
       } else {
         const match = line.match(/(status|category|editor):(.*)/)

--- a/docusaurus-utils/scrapper/markdown-convertor.mjs
+++ b/docusaurus-utils/scrapper/markdown-convertor.mjs
@@ -25,6 +25,7 @@ function enhanceMarkdownWithBulletPointsCorrected(input) {
         inContributors = true // Entering contributors section
       } else if (inContributors) {
         if (line.startsWith('  -')) {
+          console.log(line)
           contributorsLines.push(line.trim()) // Add contributors line
         } else {
           // Exiting contributors section
@@ -82,8 +83,17 @@ function parseSlugFromFrontmatter(content) {
   return 1 // Return null if not found
 }
 
+function escapeHtmlTagSymbols(content) {
+  // Escape < and > with &lt; and &gt;, respectively
+  // Be cautious with this replacement; adjust as needed based on your context
+  content = content.replace(/(?<!`)<(?!.*?`)/g, '&lt;')
+  content = content.replace(/(?<!`)>(?!.*?`)/g, '&gt;')
+
+  return content;
+}
+
 function unescapeHtmlComments(htmlString) {
-  return htmlString.replace(/\\<\!--/g, '\n<!--').replace(/--\\>/g, '-->\n')
+  return htmlString.replace(/&lt;\!--/g, '\n<!--').replace(/--&gt;/g, '-->\n')
 }
 
 function updateMarkdownLinksToExcludeMD(content) {
@@ -107,9 +117,7 @@ export function vacMarkdownToDocusaurusMarkdown(fileContent) {
   // Replace <br> with <br/>
   convertedContent = convertedContent.replace(/<br>/g, '<br/>')
 
-  // Escape < and > with \< and \>, respectively
-  // Be cautious with this replacement; adjust as needed based on your context
-  convertedContent = convertedContent.replace(/</g, '\\<').replace(/>/g, '\\>')
+  convertedContent = escapeHtmlTagSymbols(convertedContent)
 
   // NEW: Remove 'slug' line from frontmatter
   convertedContent = convertedContent.replace(/^slug:.*\n?/m, '')


### PR DESCRIPTION
# Referenced CU task IDs 🆙:
- 86b0b1634
- 86b0bzrna

# What does this PR resolve? 🚀
- Non escaped < and > character parsing
- Missing contributors on some pages fix
- Double contributors entry fix

# Details 🕵️ 
There are multiple parsing fixes done in this PR, I'll describe all of them below.

1. **Non escaped < and >**
In Docusaurus, when .md files are being parsed, we can also include html tags. In some scenarios, the Vac markdown uses less than (<) and more than (>) characters for purposes other than this.
This was tried to be fixed by using escape characters, but as it is, it doesn't seem like it's being parsed properly.
- This PR introduces a fix that uses manual html codes instead of escape character which seems to be rendered properly.
- This PR also covers edge cases in which escaping shouldn't be done like inside `inline code tags` since it's not being parsed the same inside of them

2. **Missing contributors**
The parsing was done by checking if there's a dash under contributors with manually typed-in spaces.
- This PR just uses .trim() to ensure in scenarios where convention of number of spaces isn't consistent to be handled as well

3. **Double contributor entry**
Inside the `enhanceMarkdownWithBulletPointsCorrected()` function in the `scrapper/markdown-convertor.mjs` file there was a bug where in some scenarios the _"contributors:"_ field would be added twice.
- This PR just removes the double entry

# Note ✏️
I didn't include the scrapping results as part of this PR as to make it easier for reviewing.
If all is well and we merge, we can run the script in the next commit.

# Checklist ✅
- [x] I have merged the main branch into my branch and resolved all conflicts
- [x] I have documented the new code
- [x] I have smoke tested the new code locally