### PR TITLE
feature: Support for multiple versions of the same document

### DIFF
--- a/docusaurus-utils/sidebar/classifiers.js
+++ b/docusaurus-utils/sidebar/classifiers.js
@@ -1,0 +1,50 @@
+const {
+  isIndexDocument,
+  getRFCOccurrenceMapKey
+} = require("./helpers");
+const { isNumber } = require('./utils')
+
+// By convention, Docusaurus considers some docs are "indexes":
+// - index.md
+// - readme.md
+// - <folder>/<folder>.md
+//
+// This function is the default implementation of this convention
+//
+// Those index docs produce a different behavior
+// - Slugs do not end with a weird "/index" suffix
+// - Auto-generated sidebar categories link to them as intro
+const isCategoryIndex = (rfcOccurrenceMap) => ({
+  fileName,
+  directories,
+  extension
+}) => {
+  const isIndexByName = isIndexDocument(fileName, directories[0]);
+  const isRFCWithMultipleVersions = isVersionedRFC(fileName, directories, extension, rfcOccurrenceMap);
+
+  return (isIndexByName || isRFCWithMultipleVersions)
+}
+
+function isVersionedRFC(fileName, directories, extension, rfcOccurrenceMap) {
+  if (extension.toLowerCase() !== ".md") {
+    return false;
+  }
+
+  if (!isNumber(directories[0])) {
+    return false;
+  }
+
+  if (rfcOccurrenceMap) {
+    const key = getRFCOccurrenceMapKey(fileName, extension, directories.reverse().join("/"));
+
+    if (rfcOccurrenceMap[key] >= 2) {
+      return true
+    }
+  }
+
+  return false;
+}
+
+module.exports = {
+  isCategoryIndex
+}

--- a/docusaurus-utils/sidebar/generator.js
+++ b/docusaurus-utils/sidebar/generator.js
@@ -5,9 +5,15 @@ const {
   separateFoldersAndFilesOrder,
   orderAlphabeticallyAndByNumber
 } = require("./modifiers")
+const { isCategoryIndex } = require("./classifiers")
+const { rawDocsToRFCOccurrenceMap } = require("./helpers")
 
 async function sidebarItemsGenerator({defaultSidebarItemsGenerator, ...args}) {
-  const defaultSidebarItems = await defaultSidebarItemsGenerator(args);
+  const rfcOccurrenceMap = rawDocsToRFCOccurrenceMap(args.docs)
+  const defaultSidebarItems = await defaultSidebarItemsGenerator({
+    ...args,
+    isCategoryIndex: isCategoryIndex(rfcOccurrenceMap)
+  });
 
   /*
   We'll have multiple O(N) passes through the items depending on the reducer implementation,

--- a/docusaurus-utils/sidebar/helpers.js
+++ b/docusaurus-utils/sidebar/helpers.js
@@ -1,3 +1,5 @@
+const path = require("path")
+
 function isIndexDocument(documentId, parentDirectory) {
   if (!documentId) {
     return false
@@ -10,6 +12,41 @@ function isIndexDocument(documentId, parentDirectory) {
   )
 }
 
+function rawDocsToRFCOccurrenceMap(rawDocs) {
+  /*
+  Map containing occurrences of items
+  The key is made of (Root Numbered Folder + lowercase(Filename + Extension))
+  The value is number of occurrences
+   */
+  const occurrenceMap = {}
+
+  rawDocs.forEach(rawDoc => {
+    const { name, ext } = path.parse(rawDoc.source)
+    const key = getRFCOccurrenceMapKey(name, ext, rawDoc.sourceDirName)
+
+    if (key) {
+      occurrenceMap[key] = (occurrenceMap[key] || 0) + 1;
+    }
+  })
+
+  return occurrenceMap
+}
+
+function getRFCOccurrenceMapKey(fileName, ext, dir) {
+  const parsedDir = dir[0] !== "/" ? `/${dir}` : dir.toString();
+  const parsedExt = ext[0] === "." ? ext.slice(1) : ext;
+
+  const match = parsedDir.match(/.*\/\d+(?=\/|$)/)
+  if (match) {
+    const rootNumberedRFC = match[0]
+    return `${rootNumberedRFC}/${fileName.toLowerCase()}.${parsedExt.toLowerCase()}`
+  } else {
+    return undefined
+  }
+}
+
 module.exports = {
-  isIndexDocument
+  isIndexDocument,
+  getRFCOccurrenceMapKey,
+  rawDocsToRFCOccurrenceMap
 }

--- a/docusaurus-utils/sidebar/utils.js
+++ b/docusaurus-utils/sidebar/utils.js
@@ -1,8 +1,8 @@
 function isNumber(value) {
-  if (true === Array.isArray(value)) {
+  if (Array.isArray(value)) {
     return false;
   }
-  return !isNaN(parseInt(value, 10));
+  return !isNaN(value);
 }
 
 /*


### PR DESCRIPTION
# Referenced CU task IDs 🆙:
- 86b03jzv5

# What does this PR resolve? 🚀
- Support for multiple versions of the same file/rfc/document

# Details 🕵️ 
In scenarios where we have multiple versions of the same file, like it's the case for `waku/12` RFC, we need to be able to display it under the same category
![Screenshot 2024-05-12 at 14 18 02](https://github.com/acid-info/rnd-rfc.vac.dev/assets/42151917/31ad3d43-2956-4a4f-b022-54d6edf02e23)

The end result looks like this:
![Screenshot 2024-05-12 at 14 19 16](https://github.com/acid-info/rnd-rfc.vac.dev/assets/42151917/b3e7422c-4dda-4e2e-bc52-6eb0c13ae601)
We are able to look at the current version just by clicking the link, and by clicking it, there are other versions underneath it.

**We achieve this by doing next three things basically:**
1. Finding all occurrences of the same file and counting it. We classify a same occurrence if next things are true:
- The files are named the same
- They share the same parent RFC numbered folder (eg. 12/*/.../*/filter and 12/filter)
- They are of the same file extension
2. If so, we set the main root file (12/filter) to be the index document of category 12.
3. We don't convert the category into document type if above conditions are true

# Note ✏️
I didn't include the scrapping results as part of this PR as to make it easier for reviewing.
If all is well and we merge, we can run the script in the next commit.

# Checklist ✅
- [x] I have merged the main branch into my branch and resolved all conflicts
- [x] I have documented the new code
- [x] I have smoke tested the new code locally